### PR TITLE
Add Danger integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ rvm:
   - 2.2
 before_script:
   - gem install awesome_bot
+  - gem install danger
 script:
   - awesome_bot README.md --allow-redirect --white-list pentesterlab.com
+  - danger
 notifications:
   email: false

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,8 @@
+# Check links
+require 'json'
+results = File.read 'ab-results-README.md-markdown-table.json'
+j = JSON.parse results
+if j['error']==true
+  fail j['title']
+  markdown j['message']
+end


### PR DESCRIPTION
Adds a [Danger](http://danger.systems/) integration, which allows for @InfoSecIITR-gmail to leave comments on this repo, if there are any issues with PRs (that way, we don't need to go through the Travis logs).